### PR TITLE
Allow controling the filename and using bundled certs

### DIFF
--- a/defaults/main/2_site.yml
+++ b/defaults/main/2_site.yml
@@ -8,6 +8,9 @@ defaults_site:
   port_plain: 80
   port_ssl: 443
   listen: '*'
+  name:
+  # name is used to set the filename of of the apache config file under the
+  # sites_available directory (like "site_{{name}}.conf").
   domain:
   aliases: []
   ip:
@@ -40,6 +43,11 @@ defaults_site:
     # letsencrypt:
     #   Host needs to have a valid public dns record pointed at it
     #   Needs to be publicly reachable over port 80/tcp
+    bundle: false
+    # If all necessary intermediate certificates are included in the certificate
+    # file, set bundle to true. This will prevent configuring an
+    # SSLCertificateChainFile in the apache ssl configuration, as the chain file
+    # will not exist in this use case & the config option should not be included
     cert:
       name:
       cn: 'Apache Certificate'

--- a/tasks/debian/main.yml
+++ b/tasks/debian/main.yml
@@ -157,7 +157,7 @@
   when: site.state == 'present'
   vars:
     site: "{{ defaults_site | combine(site_item.value, recursive=true) }}"
-    name: "{{ site_item.key | safe_key }}"
+    name: "{{ site_item.value.name | default(site_item.key) }}"
     path: "{{ site.serve.path }}"
   loop_control:
     loop_var: site_item

--- a/tasks/debian/main.yml
+++ b/tasks/debian/main.yml
@@ -157,7 +157,7 @@
   when: site.state == 'present'
   vars:
     site: "{{ defaults_site | combine(site_item.value, recursive=true) }}"
-    name: "{{ site_item.value.name | default(site_item.key) }}"
+    name: "{{ site_item.value.name | default(site_item.key, true) | safe_key }}"
     path: "{{ site.serve.path }}"
   loop_control:
     loop_var: site_item

--- a/templates/etc/apache2/sites-available/inc/site_https_ssl.j2
+++ b/templates/etc/apache2/sites-available/inc/site_https_ssl.j2
@@ -4,7 +4,7 @@
     SSLEngine on
     SSLCertificateKeyFile {{ APACHE_CONFIG.ssl.path }}/{{ name }}.key
     SSLCertificateFile {{ APACHE_CONFIG.ssl.path }}/{{ name }}.crt
-{% if site.ssl.mode != 'selfsigned' %}
+{% if site.ssl.mode != 'selfsigned' and not site.ssl.no_chainfile | default(true) %}
     SSLCertificateChainFile {{ APACHE_CONFIG.ssl.path }}/{{ name }}{% if site.ssl.mode == 'letsencrypt' %}.fullchain{% else %}.chain{% endif %}.crt
 {% endif %}
   </IfModule>

--- a/templates/etc/apache2/sites-available/inc/site_https_ssl.j2
+++ b/templates/etc/apache2/sites-available/inc/site_https_ssl.j2
@@ -4,7 +4,7 @@
     SSLEngine on
     SSLCertificateKeyFile {{ APACHE_CONFIG.ssl.path }}/{{ name }}.key
     SSLCertificateFile {{ APACHE_CONFIG.ssl.path }}/{{ name }}.crt
-{% if site.ssl.mode != 'selfsigned' and not site.ssl.no_chainfile | default(true) %}
+{% if site.ssl.mode != 'selfsigned' and not site.ssl.bundle | bool %}
     SSLCertificateChainFile {{ APACHE_CONFIG.ssl.path }}/{{ name }}{% if site.ssl.mode == 'letsencrypt' %}.fullchain{% else %}.chain{% endif %}.crt
 {% endif %}
   </IfModule>


### PR DESCRIPTION
This change does two things:

1. allows a name to be passed in as an argument when adding a site
2. allows using a bundled cert (no separate chain file, thus on SSLCertificateChainFile line)

Both are backward compatible so existing playbooks will not need modified while new playbooks will be possible.