### PR TITLE
Fix https config template

### DIFF
--- a/templates/etc/apache2/sites-available/inc/site_https_config.j2
+++ b/templates/etc/apache2/sites-available/inc/site_https_config.j2
@@ -21,7 +21,7 @@
 {% if site.security.restrict_methods | bool %}
   <IfModule mod_rewrite.c>
     RewriteEngine On
-    RewriteCond %{REQUEST_METHOD} ^(?!{{ for method in APACHE_CONFIG.security.restricted_methods | join('|') }})
+    RewriteCond %{REQUEST_METHOD} ^(?!{{ APACHE_CONFIG.security.restricted_methods | join('|') }})
     RewriteRule .* - [L,R=405]
   </IfModule>
   <Directory />
@@ -32,7 +32,7 @@
 {% elif site.security.deny_dangerous_methods | bool %}
   <IfModule mod_rewrite.c>
     RewriteEngine On
-    RewriteCond %{REQUEST_METHOD} ^({{ for method in APACHE_CONFIG.security.dangerous_methods | join('|') }})
+    RewriteCond %{REQUEST_METHOD} ^({{ APACHE_CONFIG.security.dangerous_methods | join('|') }})
     RewriteRule .* - [L,R=405]
   </IfModule>
   <Directory />


### PR DESCRIPTION
Issue:

TASK [ansibleguy.infra_apache : Apache | Site 'zoneminder' | Configuring site] *************************************************************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: jinja2.exceptions.TemplateSyntaxError: expected token 'end of print statement', got 'method'
fatal: [valve.lan]: FAILED! => {"changed": false, "msg": "TemplateSyntaxError: expected token 'end of print statement', got 'method'"}
